### PR TITLE
Add clearer messaging for under-indented lines

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ But this checker is designed to give you more useful messaging, and find all the
 
 example.yaml
   1:14       error    unescaped quote in quoted string
-  5:2        warning  deficient indentation
+  5:2        warning  line is under-indented (it should be indented at least 5)
 ```
 
 Instead of finding some invalid syntax before the colon on line 2, it correctly susses out that you had a quote that should have been escaped on line 1. It also flagged the under-indented value on line 5. You might think of it like [pyflakes][] in comparison to [flake8][].

--- a/lib/check.js
+++ b/lib/check.js
@@ -157,6 +157,9 @@ function check (yamlText, {filename, debug = false, fix = false, removeInvalidCh
         // Keep track of indentation warnings so can update them if they get
         // fixed later on.
         if (warning.message.includes('deficient indentation')) {
+          const expectedIndent = tokenIndent + 1;
+          warning.reason = `line is under-indented (it should be indented at least ${expectedIndent})`;
+          warning.message = `${warning.reason} ${warning.mark}`;
           tokenIndentWarnings.push(warning);
         }
       },

--- a/test/check.test.js
+++ b/test/check.test.js
@@ -336,10 +336,12 @@ describe('checker', function () {
     assert.equal(issues[0].level, 'warning');
     assert.equal(issues[0].mark.line, 3, 'The first bad indent line');
     assert.equal(issues[0].mark.column, 0, 'The first bad indent column');
+    assertIncludes(issues[0].message, 'at least 3');
 
     assert.equal(issues[1].level, 'warning');
     assert.equal(issues[1].mark.line, 4, 'The second bad indent line');
     assert.equal(issues[1].mark.column, 1, 'The second bad indent column');
+    assertIncludes(issues[1].message, 'at least 3');
   });
 
   it('can fix unindented lines in scalars', function () {


### PR DESCRIPTION
Add a clearer message than “deficient indentation” when a line is under-indented, including how much the line *should* be indented. The indentation warning now looks like:

```
line is under-indented (it should be indented at least 5)
```

Or:

```
example.yaml
  5:2        warning  line is under-indented (it should be indented at least 5)
```

Like the issue already noted in the source with *fixing* bad indentation, it’s imperfect because we don’t know whether tabs or spaces are being used, so the message isn’t as nice as it could be. That still needs doing, but I think it’s out of scope here.

Fixes #1.