### PR TITLE
Add CLI support for globs, directories, and multiple paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,8 @@ indented:
 
 If you check a `.md` (Markdown) file, YAML Doctor is also smart enough to check just the front-matter, and only if it looks like YAML front-matter :)
 
+If you check a directory, YAML Doctor will look for all the `.yaml`, `.yml`, and `.md` files in it.
+
 
 **What kinds of errors does it address?**
 
@@ -148,6 +150,7 @@ And run it on a file:
 - `--fix` Fix any issues that can be safely resolved automatically.
 - `--debug` Print debug messages while parsing.
 - `--help` Print information about usage and options.
+- `--version` Print the version of YAML Doctor that your are running.
 
 
 ### Library
@@ -221,8 +224,6 @@ First off, a HUGE thanks to [Asana, Inc.][asana] for support the development of 
 
 - Work to see how the ideas here might be integrated into existing YAML parsers. In many cases, parsers might be able to offer clearer messaging like what’s found here. Of course, this package does a lot of extra work not to stop early or to look at the surrounding context to determine what might have been intended. A lot of that might be reasonably outside the scope of a parser.
     - Work with [`js-yaml`][js-yaml] authors to solidify the private interfaces this relies on!
-
-- Support walking directory trees in the command-line application (it currently only supports single files).
 
 - Clean up checking code and split different issue types into separate "rule" objects so it’s a little easier to manage.
 

--- a/bin/yaml-doctor
+++ b/bin/yaml-doctor
@@ -10,8 +10,11 @@
 
 const chalk = require('chalk');
 const format = require('../lib/format');
+const fs = require('fs');
+const glob = require('glob');
 const optionator = require('optionator');
 const path = require('path');
+const util = require('util');
 const yamlDoctor = require('..');
 
 const optionParser = optionator({
@@ -62,31 +65,102 @@ function runWithOptions (callback) {
     process.exitCode = 1;
   }
   else {
-    callback(options);
+    Promise.resolve(callback(options)).catch(error => {
+      process.exitCode = 1;
+      console.error(error.message);
+    });
   }
 }
 
-runWithOptions(options => {
-  const filePath = options._[0];
-  yamlDoctor.checkFile(filePath, null, options)
-    .then(result => {
-      if (result.issues.length) {
-        format.printIssues(filePath, result.issues);
-        if (result.issues.some(issue => issue.level === 'error')) {
-          process.exitCode = 1;
+const statFile = util.promisify(fs.stat);
+
+async function normalizePattern (pattern) {
+  try {
+    const stat = await statFile(pattern);
+    if (stat.isDirectory()) {
+      // TODO: make these extensions customizable
+      return path.join(pattern, '**', '*.{yaml,yml,md}');
+    }
+  }
+  catch (error) {
+    // Assume this is a glob and just continue on
+  }
+
+  return pattern;
+}
+
+function globPromise (pattern, options) {
+  return new Promise((resolve, reject) => {
+    glob(pattern, options, (error, files) => {
+      if (error) reject(error);
+      else resolve(files);
+    });
+  });
+}
+
+async function resolvePaths (patterns) {
+  const pathSets = await Promise.all(patterns.map(
+    path => normalizePattern(path).then(path => globPromise(path, {realpath: true}))
+  ));
+
+  return pathSets.reduce((flat, paths) => flat.concat(paths), []);
+}
+
+runWithOptions(async options => {
+  const filePaths = await resolvePaths(options._);
+
+  if (!filePaths.length) {
+    console.error('No files matched the given paths');
+    process.exitCode = 1;
+  }
+  else {
+    let fileCount = 0;
+    let errorCount = 0;
+    let warningCount = 0;
+    let fixedCount = 0;
+    let fileErrors = [];
+
+    for (let filePath of filePaths) {
+      fileCount++;
+
+      let result;
+      try {
+        result = await yamlDoctor.checkFile(filePath, null, options);
+      }
+      catch (error) {
+        // If the file couldn't be read, log the error but keep going.
+        if (error.code === 'ENOENT') {
+          fileErrors.push(filePath);
+          errorCount += 1;
+          continue;
+        }
+        // For other unknown errors, bail out!
+        else {
+          throw error;
         }
       }
-      else {
-        console.log('No issues!');
+      const issues = result.issues;
+
+      if (issues.length) {
+        format.printIssues(filePath, issues);
+        issues.forEach(issue => {
+          if (issue.level === 'error') errorCount++;
+          else if (issue.level === 'fixed') fixedCount++;
+          else warningCount++;
+        });
       }
-    })
-    .catch(error => {
-      if (error.code === 'ENOENT') {
-        console.error(`No file at path: ${filePath}`);
-      }
-      else {
-        console.error(error);
-      }
+    }
+
+    if (fileErrors.length) {
+      const fileText = fileErrors.length === 1 ? 'file' : 'files';
+      console.log(`Could not read ${fileErrors.length} ${fileText}:`);
+      fileErrors.forEach(path => console.log(`  ${path}`));
+      console.log();
+    }
+
+    console.log(`${errorCount} errors, ${warningCount} warnings, ${fixedCount} fixed in ${fileCount} files.`);
+    if (errorCount > 0) {
       process.exitCode = 1;
-    });
+    }
+  }
 });

--- a/bin/yaml-doctor
+++ b/bin/yaml-doctor
@@ -8,27 +8,66 @@
 
 'use strict';
 
-const yamlDoctor = require('..');
+const chalk = require('chalk');
 const format = require('../lib/format');
+const optionator = require('optionator');
+const path = require('path');
+const yamlDoctor = require('..');
 
-const usage = `Check YAML for syntax errors.
-Usage: yaml-doctor <PATH> [--fix]
+const optionParser = optionator({
+  prepend: 'Check YAML files for syntax errors.\n\nUsage: yaml-doctor [options] <PATH...>',
+  options: [
+    {
+      option: 'help',
+      type: 'Boolean',
+      description: 'Display list of command-line options'
+    },
+    {
+      option: 'version',
+      type: 'Boolean',
+      description: 'Show version number'
+    },
+    {
+      option: 'fix',
+      type: 'Boolean',
+      description: 'Fix any automatically resolvable errors'
+    },
+    {
+      option: 'debug',
+      type: 'Boolean',
+      description: 'Print debug messages'
+    }
+  ]
+});
 
-Options:
-  --help   Print this help message.
-  --fix    Fix any automatically resolvable errors.
-  --debug  Print debug messages.`;
+function runWithOptions (callback) {
+  let options;
+  try {
+    options = optionParser.parseArgv(process.argv);
+  }
+  catch (error) {
+    console.error(chalk.red(error.message), '\n');
+    options = {help: true};
+  }
 
-const filePath = process.argv[2];
-if (!filePath || process.argv.includes('--help')) {
-  console.log(usage);
+  if (options.help) {
+    console.log(optionParser.generateHelp());
+  }
+  else if (options.version) {
+    const version = require(path.join(__dirname, '..', 'package.json')).version;
+    console.log('Version', version);
+  }
+  else if (options._.length === 0) {
+    console.error('You must provide at least one path or glob to check');
+    process.exitCode = 1;
+  }
+  else {
+    callback(options);
+  }
 }
-else {
-  const options = {
-    fix: process.argv.includes('--fix'),
-    debug: process.argv.includes('--debug')
-  };
 
+runWithOptions(options => {
+  const filePath = options._[0];
   yamlDoctor.checkFile(filePath, null, options)
     .then(result => {
       if (result.issues.length) {
@@ -50,4 +89,4 @@ else {
       }
       process.exitCode = 1;
     });
-}
+});

--- a/bin/yaml-doctor
+++ b/bin/yaml-doctor
@@ -8,6 +8,7 @@
 
 'use strict';
 
+const Batch = require('../lib/batch');
 const chalk = require('chalk');
 const format = require('../lib/format');
 const fsPromises = require('../lib/fs-promises');
@@ -111,53 +112,12 @@ runWithOptions(async options => {
     process.exitCode = 1;
   }
   else {
-    let fileCount = 0;
-    let errorCount = 0;
-    let warningCount = 0;
-    let fixedCount = 0;
-    let fileErrors = [];
-
+    const batch = new Batch(options);
     for (let filePath of filePaths) {
-      fileCount++;
-
-      let result;
-      try {
-        result = await yamlDoctor.checkFile(filePath, null, options);
-      }
-      catch (error) {
-        // If the file couldn't be read, log the error but keep going.
-        if (error.code === 'ENOENT') {
-          fileErrors.push(filePath);
-          errorCount += 1;
-          continue;
-        }
-        // For other unknown errors, bail out!
-        else {
-          throw error;
-        }
-      }
-      const issues = result.issues;
-
-      if (issues.length) {
-        format.printIssues(filePath, issues);
-        issues.forEach(issue => {
-          if (issue.level === 'error') errorCount++;
-          else if (issue.level === 'fixed') fixedCount++;
-          else warningCount++;
-        });
-      }
+      await batch.reportFile(filePath, null);
     }
 
-    if (fileErrors.length) {
-      const fileText = fileErrors.length === 1 ? 'file' : 'files';
-      console.log(`Could not read ${fileErrors.length} ${fileText}:`);
-      fileErrors.forEach(path => console.log(`  ${path}`));
-      console.log();
-    }
-
-    console.log(`${errorCount} errors, ${warningCount} warnings, ${fixedCount} fixed in ${fileCount} files.`);
-    if (errorCount > 0) {
-      process.exitCode = 1;
-    }
+    batch.reportSummary();
+    batch.setExitCode();
   }
 });

--- a/bin/yaml-doctor
+++ b/bin/yaml-doctor
@@ -14,6 +14,7 @@ const fsPromises = require('../lib/fs-promises');
 const glob = require('glob');
 const optionator = require('optionator');
 const path = require('path');
+const util = require('util');
 
 const optionParser = optionator({
   prepend: 'Check YAML files for syntax errors.\n\nUsage: yaml-doctor [options] <PATH...>',
@@ -85,14 +86,7 @@ async function normalizePattern (pattern) {
   return pattern;
 }
 
-function globPromise (pattern, options) {
-  return new Promise((resolve, reject) => {
-    glob(pattern, options, (error, files) => {
-      if (error) reject(error);
-      else resolve(files);
-    });
-  });
-}
+const globPromise = util.promisify(glob);
 
 async function resolvePaths (patterns) {
   const pathSets = await Promise.all(patterns.map(

--- a/bin/yaml-doctor
+++ b/bin/yaml-doctor
@@ -10,11 +10,10 @@
 
 const chalk = require('chalk');
 const format = require('../lib/format');
-const fs = require('fs');
+const fsPromises = require('../lib/fs-promises');
 const glob = require('glob');
 const optionator = require('optionator');
 const path = require('path');
-const util = require('util');
 const yamlDoctor = require('..');
 
 const optionParser = optionator({
@@ -72,11 +71,9 @@ function runWithOptions (callback) {
   }
 }
 
-const statFile = util.promisify(fs.stat);
-
 async function normalizePattern (pattern) {
   try {
-    const stat = await statFile(pattern);
+    const stat = await fsPromises.stat(pattern);
     if (stat.isDirectory()) {
       // TODO: make these extensions customizable
       return path.join(pattern, '**', '*.{yaml,yml,md}');

--- a/bin/yaml-doctor
+++ b/bin/yaml-doctor
@@ -10,12 +10,10 @@
 
 const Batch = require('../lib/batch');
 const chalk = require('chalk');
-const format = require('../lib/format');
 const fsPromises = require('../lib/fs-promises');
 const glob = require('glob');
 const optionator = require('optionator');
 const path = require('path');
-const yamlDoctor = require('..');
 
 const optionParser = optionator({
   prepend: 'Check YAML files for syntax errors.\n\nUsage: yaml-doctor [options] <PATH...>',

--- a/lib/batch.js
+++ b/lib/batch.js
@@ -1,0 +1,137 @@
+'use strict';
+
+const check = require('./check');
+const format = require('../lib/format');
+
+// Errors that we expect to receive if a file could not be read. These aren't
+// fatal, since we expect that there might be a few bad paths in a large batch.
+// `fs` could give us other errors, but these are the only ones we expect to
+// see because we are are not writing directories or links.
+const unreadableErrors = new Set(
+  'ENOENT',
+  'EPERM'
+);
+
+// Super naive pluralizer. Only works for languages like English and for simple
+// words that you just need to add 's' to the end of.
+function pluralize (text, count) {
+  if (count !== 1) return text + 's';
+  return text;
+}
+
+// Add a correctly pluralized unit to the end of a number.
+function withUnit (unit, count) {
+  return `${count} ${pluralize(unit, count)}`;
+}
+
+/**
+ * Batch keeps a record of results across a series of file checks and can
+ * report file results and summary results.
+ */
+class Batch {
+  constructor (options = null) {
+    this.options = options;
+    this.summary = {
+      files: 0,
+      errors: 0,
+      warnings: 0,
+      fixed: 0,
+      unreadablePaths: []
+    };
+  }
+
+  /**
+   * Whether the batch has encountered any errors in the files checked so far.
+   */
+  get hasErrors () {
+    return this.summary.errors > 0;
+  }
+
+  /**
+   * Check a file for YAML issues. This differs from `check.checkFile()` in
+   * that it will return `null` instead of throwing an error if the file could
+   * not be read, under the assumption that these errors are not fatal for a
+   * whole batch of files.
+   *
+   * @param {string} filePath Path to file to check
+   * @param {Buffer} [content] Optional content of the file.
+   * @param {any} [options]  Options to pass to `check`.
+   * @returns {Promise<{issues: Array<YAMLException>, fixed: string}>|null}
+   */
+  async checkFile (filePath, content, options = null) {
+    options = Object.assign({}, this.options, options);
+
+    try {
+      const result = await check.checkFile(filePath, content, options);
+
+      result.issues.forEach(issue => {
+        if (issue.level === 'error') this.summary.errors++;
+        else if (issue.level === 'fixed') this.summary.fixed++;
+        else this.summary.warnings++;
+      });
+
+      return result;
+    }
+    catch (error) {
+      // Track errors for paths that could not be read/written. Other errors
+      // will be actual errors in our code and should be fatal.
+      if (unreadableErrors.has(error.code)) {
+        this.summary.unreadablePaths.add(filePath);
+        this.summary.errors += 1;
+        return null;
+      }
+
+      throw error;
+    }
+    finally {
+      this.summary.files += 1;
+    }
+  }
+
+  /**
+   * Check a file for YAML issues and write the results to STDOUT/STDERR.
+   * @param {string} filePath Path to file to check
+   * @param {Buffer} [content] Optional content of the file.
+   * @param {any} [options]  Options to pass to `check`.
+   */
+  async reportFile (filePath, content, options = null) {
+    const result = await this.checkFile(filePath, content, options);
+
+    if (result && result.issues.length) {
+      format.printIssues(filePath, result.issues);
+    }
+  }
+
+  /**
+   * Write a summary of found/fixed issues to STDOUT.
+   */
+  reportSummary () {
+    // List any files that couldn't be read.
+    if (this.summary.unreadablePaths.length) {
+      const unreadable = this.summary.unreadablePaths;
+      const fileText = unreadable.length === 1 ? 'file' : 'files';
+      console.log(`Could not read ${unreadable.length} ${fileText}:`);
+      unreadable.forEach(path => console.log(`  ${path}`));
+      console.log();
+    }
+
+    // Count files and types of issues.
+    const breakdown = [
+      withUnit('error', this.summary.errors),
+      withUnit('warning', this.summary.warnings),
+      `${this.summary.fixed} fixed`
+    ].join(', ');
+    console.log(`${breakdown} in ${withUnit('file', this.summary.files)}`);
+  }
+
+  /**
+   * Set the process's exit code based on the results.
+   */
+  setExitCode () {
+    if (this.hasErrors) {
+      process.exitCode = 1;
+    }
+  }
+}
+
+module.exports = Batch;

--- a/lib/check.js
+++ b/lib/check.js
@@ -10,7 +10,7 @@
 'use strict';
 
 const chalk = require('chalk');
-const fs = require('fs');
+const fsPromises = require('./fs-promises');
 const parsePage = require('./parse-page');
 const path = require('path');
 const StringEditor = require('./string-editor');
@@ -929,7 +929,7 @@ function isHexDigit (charCode) {
 async function checkFile (filePath, content = null, options = {}) {
   if (content == null) {
     // FIXME: once we update to Node.js 10, use the new fs promises API
-    content = await util.promisify(fs.readFile)(filePath, 'utf8');
+    content = await fsPromises.readFile(filePath, 'utf8');
   }
   else if (!Buffer.isBuffer(content) && typeof content !== 'string') {
     throw new TypeError('`content` must be a string');
@@ -957,7 +957,7 @@ async function checkFile (filePath, content = null, options = {}) {
     }
     else {
       // FIXME: once we update to Node.js 10, use the new fs promises API
-      await util.promisify(fs.writeFile)(filePath, fixedContent, 'utf8');
+      await fsPromises.writeFile(filePath, fixedContent, 'utf8');
     }
   }
 

--- a/lib/fs-promises.js
+++ b/lib/fs-promises.js
@@ -1,0 +1,18 @@
+'use strict';
+
+/**
+ * Export promise-based versions of `fs` features that we use. In Node.js v10,
+ * we can use fs.promises instead, but it will print a warning to the console
+ * (ok for library use, but not CLI use), and in v12 it's a-ok.
+ *
+ * TODO: Get rid of this once we drop v8 and once v12 moves to LTS.
+ */
+
+const fs = require('fs');
+const util = require('util');
+
+module.exports = {
+  readFile: util.promisify(fs.readFile),
+  stat: util.promisify(fs.stat),
+  writeFile: util.promisify(fs.writeFile)
+};

--- a/lib/gulp.js
+++ b/lib/gulp.js
@@ -6,38 +6,21 @@
 
 'use strict';
 
+const Batch = require('./batch');
 const gulpTransformStream = require('./gulp-transform-stream');
-const {checkFile} = require('./check');
 const path = require('path');
-const printIssues = require('./format').printIssues;
 
 function checkGulpFileStream (options = null) {
-  let fileCount = 0;
-  let errorCount = 0;
-  let warningCount = 0;
-  let fixedCount = 0;
+  const batch = new Batch(options);
 
   return gulpTransformStream(
     async (file, content) => {
       const filePath = path.relative(process.cwd(), file.path);
-      const {issues} = await checkFile(filePath, content, options);
-      fileCount++;
-
-      if (issues.length) {
-        printIssues(filePath, issues);
-        issues.forEach(issue => {
-          if (issue.level === 'error') errorCount++;
-          else if (issue.level === 'fixed') fixedCount++;
-          else warningCount++;
-        });
-      }
-      return issues;
+      return await batch.reportFile(filePath, content);
     },
     async () => {
-      console.log(`${errorCount} errors, ${warningCount} warnings, ${fixedCount} fixed in ${fileCount} files.`);
-      if (errorCount > 0) {
-        process.exitCode = 1;
-      }
+      batch.reportSummary();
+      batch.setExitCode();
     }
   );
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -91,14 +91,12 @@
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-      "dev": true
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
     },
     "brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-      "dev": true,
       "requires": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -186,8 +184,7 @@
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-      "dev": true
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
     },
     "cross-spawn": {
       "version": "6.0.5",
@@ -514,8 +511,7 @@
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
-      "dev": true
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
     },
     "function-bind": {
       "version": "1.1.1",
@@ -548,7 +544,6 @@
       "version": "7.1.3",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
       "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
-      "dev": true,
       "requires": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -631,7 +626,6 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-      "dev": true,
       "requires": {
         "once": "^1.3.0",
         "wrappy": "1"
@@ -640,8 +634,7 @@
     "inherits": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-      "dev": true
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
     },
     "inquirer": {
       "version": "6.3.1",
@@ -855,7 +848,6 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-      "dev": true,
       "requires": {
         "brace-expansion": "^1.1.7"
       }
@@ -1007,7 +999,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-      "dev": true,
       "requires": {
         "wrappy": "1"
       }
@@ -1111,8 +1102,7 @@
     "path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
-      "dev": true
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
     },
     "path-is-inside": {
       "version": "1.0.2",
@@ -1471,8 +1461,7 @@
     "wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-      "dev": true
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
     },
     "write": {
       "version": "1.0.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -220,8 +220,7 @@
     "deep-is": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
-      "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
-      "dev": true
+      "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ="
     },
     "define-properties": {
       "version": "1.1.3",
@@ -457,8 +456,7 @@
     "fast-levenshtein": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
-      "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
-      "dev": true
+      "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc="
     },
     "figures": {
       "version": "2.0.0",
@@ -789,7 +787,6 @@
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
       "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
-      "dev": true,
       "requires": {
         "prelude-ls": "~1.1.2",
         "type-check": "~0.3.2"
@@ -1028,7 +1025,6 @@
       "version": "0.8.2",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
       "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
-      "dev": true,
       "requires": {
         "deep-is": "~0.1.3",
         "fast-levenshtein": "~2.0.4",
@@ -1133,8 +1129,7 @@
     "prelude-ls": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
-      "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
-      "dev": true
+      "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ="
     },
     "progress": {
       "version": "2.0.3",
@@ -1384,7 +1379,6 @@
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
       "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
-      "dev": true,
       "requires": {
         "prelude-ls": "~1.1.2"
       }
@@ -1425,8 +1419,7 @@
     "wordwrap": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
-      "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
-      "dev": true
+      "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus="
     },
     "wrap-ansi": {
       "version": "2.1.0",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   },
   "dependencies": {
     "chalk": "^2.4.2",
+    "glob": "^7.1.3",
     "js-yaml": "^3.13.1",
     "optionator": "^0.8.2"
   }

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   },
   "dependencies": {
     "chalk": "^2.4.2",
-    "js-yaml": "^3.13.1"
+    "js-yaml": "^3.13.1",
+    "optionator": "^0.8.2"
   }
 }

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -1,0 +1,84 @@
+/**
+ * Copyright (C) 2019, Rob Brackett
+ * This is open source software, released under a standard 3-clause
+ * BSD-style license; see the file LICENSE for details.
+ */
+'use strict';
+
+const assert = require('assert');
+const {assertIncludes} = require('./support/assertions');
+const path = require('path');
+const spawn = require('child_process').spawn;
+
+// Run the CLI command with a list of arguments. This is a relatively light
+// promise wrapper around `child_process.spawn()`.
+function run (cliArgs, options) {
+  return new Promise((resolve, reject) => {
+    const command = path.resolve(__dirname, '..', 'bin', 'yaml-doctor');
+
+    // Technically these should be buffers, but we are always dealing with text
+    // so being lazy here works ok.
+    let stdout = '';
+    let stderr = '';
+
+    const spawnOptions = Object.assign(
+      {cwd: __dirname},
+      options,
+      {stdio: 'pipe'}
+    );
+
+    const child = spawn(command, cliArgs, spawnOptions)
+      .on('error', reject)
+      .on('close', exitCode => {
+        resolve({exitCode, stdout, stderr});
+      });
+
+    child.stdout.on('data', data => {
+      stdout += data;
+    });
+
+    child.stderr.on('data', data => {
+      stderr += data;
+    });
+  });
+}
+
+describe('YAML Doctor CLI', function () {
+  it('checks files', async function () {
+    const {exitCode, stdout} = await run(['fixtures']);
+
+    assert.equal(exitCode, 1, 'Should have exit code of `1` for errors.');
+    assertIncludes(stdout, '1 error, 2 warnings, 0 fixed in 6 files', 'It should show a summary');
+    assertIncludes(stdout, 'fixtures/only-warnings.yaml', 'It should include files with issues');
+    assertIncludes(stdout, 'fixtures/some-file.yaml', 'It should include files with issues');
+  });
+
+
+  it('should succeed if there were only warnings', async function () {
+    const {exitCode, stdout} = await run(['fixtures/*warnings*']);
+
+    assert.equal(exitCode, 0, 'Should have exit code of `0`.');
+    assertIncludes(stdout, '0 errors, 1 warning, 0 fixed in 1 file', 'It should show a summary');
+  });
+
+  it('should exit with code 1 if there were no files found', async function () {
+    const {exitCode, stderr} = await run(['fixtures/ugabooga']);
+
+    assert.equal(exitCode, 1, 'Should have exit code of `1`.');
+    assertIncludes(stderr, 'No files', 'It should show a message on stderr');
+  });
+
+  it('should only look for .yaml, .yml, and .md files in a directory', async function () {
+    const {exitCode, stdout} = await run(['fixtures/subfolder']);
+
+    assert.equal(exitCode, 0, 'Should have exit code of `0`.');
+    assertIncludes(stdout, '0 errors, 0 warnings, 0 fixed in 1 file', 'It should show a summary');
+  });
+
+  it('should check regardless of extension of an actual file or file pattern is listed', async function () {
+    const {exitCode, stdout} = await run(['fixtures/subfolder/*.txt']);
+
+    assert.equal(exitCode, 1, 'Should have exit code of `1` because the text file is not YAML.');
+    assertIncludes(stdout, '1 error, 0 warnings, 0 fixed in 1 file', 'It should show a summary');
+  });
+});

--- a/test/fixtures/another-file.yml
+++ b/test/fixtures/another-file.yml
@@ -1,0 +1,3 @@
+---
+some_key: Some Value
+another_key: Another value

--- a/test/fixtures/markdown-with-yaml.md
+++ b/test/fixtures/markdown-with-yaml.md
@@ -1,0 +1,7 @@
+---
+some_key: Some Value
+another_key: Another value
+---
+# Markdown with YAML Front-Matter
+
+Why hello, this is a Markdown file with YAML front-matter.

--- a/test/fixtures/markdown-without-yaml.md
+++ b/test/fixtures/markdown-without-yaml.md
@@ -1,0 +1,3 @@
+# Markdown with YAML Front-Matter
+
+Why hello, this is a Markdown file with YAML front-matter.

--- a/test/fixtures/only-warnings.yaml
+++ b/test/fixtures/only-warnings.yaml
@@ -1,0 +1,5 @@
+---
+some_key: Some value
+indented:
+    key: 'String that breaks across lines
+ but is not indented.'

--- a/test/fixtures/some-file.yaml
+++ b/test/fixtures/some-file.yaml
@@ -1,0 +1,5 @@
+some_key: 'It's got a quoted value with an unescaped quote'
+another_key: Some value
+indented:
+    key: 'String that breaks across lines
+ but is not indented.'

--- a/test/fixtures/subfolder/nested-file.txt
+++ b/test/fixtures/subfolder/nested-file.txt
@@ -1,0 +1,7 @@
+Hi, I'm a text file.
+
+Also: totally Not
+YAML.
+
+- Ok?
+- Yeah.

--- a/test/fixtures/subfolder/nested-yaml.yaml
+++ b/test/fixtures/subfolder/nested-yaml.yaml
@@ -1,0 +1,2 @@
+---
+this: is YAML!


### PR DESCRIPTION
This adds better support for specifying multiple paths as positional CLI arguments. Each path can be a file, a glob, or a directory (directories get treated like `directory/**/*.{yaml,yml,md}`). This makes YAML Doctor a lot more useful as a CLI tool. Now you can:

```sh
> yaml-doctor path/to/directory
# Or...
> yaml-doctor configuration/*.config
# Or...
> yaml-doctor this/file.yaml that/file.yaml some/directory/*.yaml
```

This switches from hand-written option parsing to [Optionator](https://www.npmjs.com/package/optionator) and uses [Glob](https://www.npmjs.com/package/glob) for glob matching.

This is functional, but needs a lot of cleanup. Most of this code should probably be re-organized into a `cli.js` module inside the `lib` directory and it would be good to share the implementation with the `gulp.js` module.

Fixes #2.