### PR TITLE
Add `--extensions` CLI option

### DIFF
--- a/bin/yaml-doctor
+++ b/bin/yaml-doctor
@@ -17,7 +17,7 @@ const path = require('path');
 const util = require('util');
 
 const optionParser = optionator({
-  prepend: 'Check YAML files for syntax errors.\n\nUsage: yaml-doctor [options] <PATH...>',
+  prepend: 'Check YAML files for syntax errors.\n\nUsage: yaml-doctor [options] <DIR|FILE|GLOB...>',
   options: [
     {
       option: 'help',
@@ -38,6 +38,13 @@ const optionParser = optionator({
       option: 'debug',
       type: 'Boolean',
       description: 'Print debug messages'
+    },
+    {
+      option: 'extensions',
+      type: 'Array',
+      concatRepeatedArrays: true,
+      description: 'When checking a directory, yaml-doctor will check files with these extensions inside it. Can be a comma-separated list (e.g. `--extensions .yaml,.yml`) or you can specify the argument multiple times (e.g. `--extensions .yaml --extensions .yml`).',
+      default: '.yaml,.yml,.md'
     }
   ]
 });
@@ -71,12 +78,16 @@ function runWithOptions (callback) {
   }
 }
 
-async function normalizePattern (pattern) {
+async function normalizePattern (pattern, extensions) {
   try {
     const stat = await fsPromises.stat(pattern);
     if (stat.isDirectory()) {
-      // TODO: make these extensions customizable
-      return path.join(pattern, '**', '*.{yaml,yml,md}');
+      // Glob arrays (`*.{a,b,c}`) do not work if there is only one item, so
+      // format the glob differently based on how many extensions there are.
+      const nameGlob = extensions.length > 1
+        ? `*.{${extensions.join(',')}}`
+        : `*.${extensions[0]}`;
+      return path.join(pattern, '**', nameGlob);
     }
   }
   catch (error) {
@@ -86,18 +97,24 @@ async function normalizePattern (pattern) {
   return pattern;
 }
 
+function normalizeExtensions (extensions) {
+  return extensions.map(extension => extension.replace(/^\./, ''));
+}
+
 const globPromise = util.promisify(glob);
 
-async function resolvePaths (patterns) {
-  const pathSets = await Promise.all(patterns.map(
-    path => normalizePattern(path).then(path => globPromise(path, {realpath: true}))
-  ));
+async function resolvePaths (patterns, extensions) {
+  const pathSets = await Promise.all(patterns.map(async (path) => {
+    const pattern = await normalizePattern(path, extensions);
+    return globPromise(pattern, {realpath: true});
+  }));
 
-  return pathSets.reduce((flat, paths) => flat.concat(paths), []);
+  return pathSets.flat();
 }
 
 runWithOptions(async options => {
-  const filePaths = await resolvePaths(options._);
+  const extensions = normalizeExtensions(options.extensions);
+  const filePaths = await resolvePaths(options._, extensions);
 
   if (!filePaths.length) {
     console.error('No files matched the given paths');

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -81,4 +81,12 @@ describe('YAML Doctor CLI', function () {
     assert.equal(exitCode, 1, 'Should have exit code of `1` because the text file is not YAML.');
     assertIncludes(stdout, '1 error, 0 warnings, 0 fixed in 1 file', 'It should show a summary');
   });
+
+  it('should look for files matching --ext if set', async function () {
+    const {exitCode, stdout} = await run(['--extensions', '.uhoh', 'fixtures']);
+
+    assert.equal(exitCode, 1, 'Should have exit code of `0`.');
+    assertIncludes(stdout, 'fixtures/some-file.uhoh');
+    assertIncludes(stdout, '1 error, 1 warning, 0 fixed in 1 file');
+  });
 });

--- a/test/fixtures/some-file.uhoh
+++ b/test/fixtures/some-file.uhoh
@@ -1,0 +1,5 @@
+some_key: 'It's got a quoted value with an unescaped quote'
+another_key: Some value
+indented:
+    key: 'String that breaks across lines
+ but is not indented.'


### PR DESCRIPTION
This adds a `--extensions` CLI option that specifies what file name extensions to match when yaml-doctor is dealing with a directory instead of a file path. To specify more than one extension, you can use a comma-separated list or you can repeat the option:

```sh
# Comma-separated:
yaml-doctor --extensions .yaml,.yml path/to/directory

# Exactly the same, but with repeated options:
yaml-doctor --extensions .yaml --extensions .yml path/to/directory
```

Fixes #3.