### PR TITLE
Handle globs instead of paths that match directories

### DIFF
--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -11,7 +11,7 @@ globals:
     SharedArrayBuffer: readonly
 
 parserOptions:
-    ecmaVersion: 2018
+    ecmaVersion: 2021
 
 rules:
     indent:

--- a/bin/yaml-doctor
+++ b/bin/yaml-doctor
@@ -11,6 +11,7 @@
 const Batch = require('../lib/batch');
 const chalk = require('chalk');
 const { globIterate } = require('glob');
+const { LRUCache } = require('lru-cache');
 const optionator = require('optionator');
 const path = require('path');
 
@@ -73,12 +74,20 @@ function makeDirectoryGlob (directoryPath) {
   return path.join(directoryPath, '**', '*.{yaml,yml,md}');
 }
 
-async function * resolvePaths (patterns) {
+async function * resolvePaths (patterns, cache = null) {
+  cache ||= new LRUCache({max: 1_000});
+
   for await (const entry of globIterate(patterns, {realpath: true, withFileTypes: true})) {
+    const fullpath = entry.fullpath();
+    if (cache.has(fullpath)) {
+      continue;
+    }
+
+    cache.set(fullpath, true);
     if (entry.isDirectory()) {
-      yield *resolvePaths(makeDirectoryGlob(entry.fullpath()));
+      yield *resolvePaths(makeDirectoryGlob(entry.fullpath()), cache);
     } else {
-      yield entry.fullpath();
+      yield fullpath;
     }
   }
 }

--- a/bin/yaml-doctor
+++ b/bin/yaml-doctor
@@ -10,8 +10,7 @@
 
 const Batch = require('../lib/batch');
 const chalk = require('chalk');
-const fsPromises = require('fs/promises');
-const { glob } = require('glob');
+const { globIterate } = require('glob');
 const optionator = require('optionator');
 const path = require('path');
 
@@ -70,41 +69,30 @@ function runWithOptions (callback) {
   }
 }
 
-async function normalizePattern (pattern) {
-  try {
-    const stat = await fsPromises.stat(pattern);
-    if (stat.isDirectory()) {
-      // TODO: make these extensions customizable
-      return path.join(pattern, '**', '*.{yaml,yml,md}');
-    }
-  }
-  catch (error) {
-    // Assume this is a glob and just continue on
-  }
-
-  return pattern;
+function makeDirectoryGlob (directoryPath) {
+  return path.join(directoryPath, '**', '*.{yaml,yml,md}');
 }
 
-async function resolvePaths (patterns) {
-  // TODO: this is kind of backward -- it expands directories before globbing
-  // instead of after, even though a glob could match a directory.
-  const normalized = await Promise.all(patterns.map(normalizePattern));
-  return await glob(normalized, {realpath: true});
+async function * resolvePaths (patterns) {
+  for await (const entry of globIterate(patterns, {realpath: true, withFileTypes: true})) {
+    if (entry.isDirectory()) {
+      yield *resolvePaths(makeDirectoryGlob(entry.fullpath()));
+    } else {
+      yield entry.fullpath();
+    }
+  }
 }
 
 runWithOptions(async options => {
-  const filePaths = await resolvePaths(options._);
+  const batch = new Batch(options);
+  for await (const filePath of resolvePaths(options._)) {
+    await batch.reportFile(filePath, null);
+  }
 
-  if (!filePaths.length) {
+  if (batch.summary.files === 0) {
     console.error('No files matched the given paths');
     process.exitCode = 1;
-  }
-  else {
-    const batch = new Batch(options);
-    for (let filePath of filePaths) {
-      await batch.reportFile(filePath, null);
-    }
-
+  } else {
     batch.reportSummary();
     batch.setExitCode();
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "chalk": "^4.1.2",
         "glob": "9.3.5",
         "js-yaml": "^3.14.1",
-        "lru-cache": "<10.3.1",
+        "lru-cache": "10.3.0",
         "optionator": "^0.9.1"
       },
       "bin": {

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "chalk": "^4.1.2",
     "glob": "9.3.5",
     "js-yaml": "^3.14.1",
-    "lru-cache": "<10.3.1",
+    "lru-cache": "10.3.0",
     "optionator": "^0.9.1"
   },
   "engines" : {

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -102,4 +102,11 @@ describe('YAML Doctor CLI', function () {
     assert.equal(exitCode, 1, 'Should have exit code of `1`.');
     assertIncludes(stdout, '1 error, 0 warnings, 0 fixed in 2 files');
   });
+
+  it('should work with globs that match a directory', async function () {
+    const {exitCode, stdout} = await run(['fixtures/subfolde*']);
+
+    assert.equal(exitCode, 0, 'Should have exit code of `0`.');
+    assertIncludes(stdout, '0 errors, 0 warnings, 0 fixed in 1 file');
+  });
 });

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -95,12 +95,12 @@ describe('YAML Doctor CLI', function () {
 
   it('should not check the same file multiple times', async function() {
     const {exitCode, stdout} = await run([
-      'fixtures/subfolder/*',
-      'fixtures/subfolder/*.txt'
+      'fixtures/subfolder/*.yaml',
+      'fixtures/subfolde*'
     ]);
 
-    assert.equal(exitCode, 1, 'Should have exit code of `1`.');
-    assertIncludes(stdout, '1 error, 0 warnings, 0 fixed in 2 files');
+    assert.equal(exitCode, 0, 'Should have exit code of `0`.');
+    assertIncludes(stdout, '0 errors, 0 warnings, 0 fixed in 1 file');
   });
 
   it('should work with globs that match a directory', async function () {


### PR DESCRIPTION
Fixes #30.

When you ask YAML-Doctor to check a directory (or directories), it looks inside the directory for YAML files:

```
yaml-doctor path/to/directory
yaml-doctor path/to/directory-pattern*
```

But if you pass a directory-matching pattern directly (instead of having your shell interpret it), we fail:

```
yaml-doctor 'path/to/directory-pattern*'
```

This solves the issue by handling directories *while* globbing instead of before globbing.

~⚠️ I’m keeping this a draft for now because I’m not 100% sure this is the best approach — it may be better to leave globbing up to the shell (so YAML-Doctor should only engage in globbing if handed a directory, not for all paths/patterns it is given). This also has an issue where I broke file uniqueness that needs fixing.~ *(Update: decided this was fine.)*